### PR TITLE
Adding string sanitization for protos containing `.` and fixing casing

### DIFF
--- a/src/main/java/com/vizor/unreal/convert/ClientWorkerGenerator.java
+++ b/src/main/java/com/vizor/unreal/convert/ClientWorkerGenerator.java
@@ -13,6 +13,11 @@
  * License for the specific language governing permissions and limitations
  * under the License.
  */
+
+/*
+ * Modified 2021 by Singularity 6, Inc.
+ */
+
 package com.vizor.unreal.convert;
 
 import com.squareup.wire.schema.internal.parser.ProtoFileElement;

--- a/src/main/java/com/vizor/unreal/convert/ClientWorkerGenerator.java
+++ b/src/main/java/com/vizor/unreal/convert/ClientWorkerGenerator.java
@@ -42,6 +42,9 @@ import static com.vizor.unreal.tree.CppType.Kind.Class;
 import static com.vizor.unreal.tree.CppType.Kind.Struct;
 import static com.vizor.unreal.tree.CppType.plain;
 import static com.vizor.unreal.tree.CppType.wildcardGeneric;
+// s6fix @bernst - Generate C++ safe and compilable code.
+import static com.vizor.unreal.util.Misc.packageNameToCppNamespace;
+// s6fix_end
 import static java.lang.String.join;
 import static java.lang.System.lineSeparator;
 import static java.text.MessageFormat.format;
@@ -252,7 +255,7 @@ class ClientWorkerGenerator
 
     private String getPackageNamespaceString()
     {
-        return parse.packageName() != null ? parse.packageName() + "::" : "";
+        return parse.packageName() != null ? packageNameToCppNamespace(parse.packageName()) + "::" : "";
     }
 
 }

--- a/src/main/java/com/vizor/unreal/convert/ClientWorkerGenerator.java
+++ b/src/main/java/com/vizor/unreal/convert/ClientWorkerGenerator.java
@@ -42,9 +42,7 @@ import static com.vizor.unreal.tree.CppType.Kind.Class;
 import static com.vizor.unreal.tree.CppType.Kind.Struct;
 import static com.vizor.unreal.tree.CppType.plain;
 import static com.vizor.unreal.tree.CppType.wildcardGeneric;
-// s6fix @bernst - Generate C++ safe and compilable code.
 import static com.vizor.unreal.util.Misc.packageNameToCppNamespace;
-// s6fix_end
 import static java.lang.String.join;
 import static java.lang.System.lineSeparator;
 import static java.text.MessageFormat.format;
@@ -255,9 +253,7 @@ class ClientWorkerGenerator
 
     private String getPackageNamespaceString()
     {
-        // s6fix @bernst - Generate C++ safe and compilable code.
         return parse.packageName() != null ? packageNameToCppNamespace(parse.packageName()) + "::" : "";
-        // s6fix_end
     }
 
 }

--- a/src/main/java/com/vizor/unreal/convert/ClientWorkerGenerator.java
+++ b/src/main/java/com/vizor/unreal/convert/ClientWorkerGenerator.java
@@ -255,7 +255,9 @@ class ClientWorkerGenerator
 
     private String getPackageNamespaceString()
     {
+        // s6fix @bernst - Generate C++ safe and compilable code.
         return parse.packageName() != null ? packageNameToCppNamespace(parse.packageName()) + "::" : "";
+        // s6fix_end
     }
 
 }

--- a/src/main/java/com/vizor/unreal/convert/ProtoProcessor.java
+++ b/src/main/java/com/vizor/unreal/convert/ProtoProcessor.java
@@ -61,6 +61,7 @@ import static com.vizor.unreal.tree.CppRecord.Residence.Header;
 import static com.vizor.unreal.tree.CppType.Kind.Enum;
 import static com.vizor.unreal.tree.CppType.Kind.Struct;
 import static com.vizor.unreal.tree.CppType.plain;
+import static com.vizor.unreal.util.Misc.mixedCharacterStringToCppSafe;
 import static com.vizor.unreal.util.Misc.reorder;
 import static com.vizor.unreal.util.Misc.snakeCaseToCamelCase;
 import static com.vizor.unreal.util.Misc.stringIsNullOrEmpty;
@@ -86,7 +87,7 @@ class ProtoProcessorArgs
 
         this.wrapperName = removeExtension(pathToProto.toFile().getName());
 
-        this.className = snakeCaseToCamelCase(wrapperName);
+        this.className = mixedCharacterStringToCppSafe(wrapperName);
 
 //        if (parse.packageName() == null)
 //            throw new RuntimeException("package filed in proto file is required for cornerstone");
@@ -465,9 +466,9 @@ class ProtoProcessor implements Runnable
     private CppType ueNamedType(final String serviceName, final TypeElement el)
     {
         if (el instanceof MessageElement)
-            return plain("F" + serviceName + "_" + el.name(), Struct);
+            return plain("F" + mixedCharacterStringToCppSafe(serviceName) + "_" + el.name(), Struct);
         else if (el instanceof EnumElement)
-            return plain("E" + serviceName + "_" + el.name(), Enum);
+            return plain("E" + mixedCharacterStringToCppSafe(serviceName) + "_" + el.name(), Enum);
         else
             throw new RuntimeException("Unknown type: '" + el.getClass().getName() + "'");
     }

--- a/src/main/java/com/vizor/unreal/convert/ProtoProcessor.java
+++ b/src/main/java/com/vizor/unreal/convert/ProtoProcessor.java
@@ -61,7 +61,9 @@ import static com.vizor.unreal.tree.CppRecord.Residence.Header;
 import static com.vizor.unreal.tree.CppType.Kind.Enum;
 import static com.vizor.unreal.tree.CppType.Kind.Struct;
 import static com.vizor.unreal.tree.CppType.plain;
+// s6fix @bernst - Generate C++ safe and compilable code.
 import static com.vizor.unreal.util.Misc.mixedCharacterStringToCppSafe;
+// s6fix_end
 import static com.vizor.unreal.util.Misc.reorder;
 import static com.vizor.unreal.util.Misc.snakeCaseToCamelCase;
 import static com.vizor.unreal.util.Misc.stringIsNullOrEmpty;
@@ -85,9 +87,11 @@ class ProtoProcessorArgs
         this.pathToConverted = requireNonNull(pathToConverted2);
         this.moduleName = requireNonNull(moduleName);
 
-        this.wrapperName = removeExtension(pathToProto.toFile().getName());
+        // s6fix @bernst - Generate C++ safe and compilable code. I haven't confirmed this helps anything. We probably should wrap pathToProto above to be safe as well, since that probably affects the generated file, and macro that can fail to compile.
+        this.wrapperName = mixedCharacterStringToCppSafe(removeExtension(pathToProto.toFile().getName()));
 
-        this.className = mixedCharacterStringToCppSafe(wrapperName);
+        this.className = wrapperName;
+        // s6fix_end
 
 //        if (parse.packageName() == null)
 //            throw new RuntimeException("package filed in proto file is required for cornerstone");
@@ -465,12 +469,21 @@ class ProtoProcessor implements Runnable
 
     private CppType ueNamedType(final String serviceName, final TypeElement el)
     {
+        // s6fix @bernst - Generate C++ safe and compilable code.
         if (el instanceof MessageElement)
+        {
             return plain("F" + mixedCharacterStringToCppSafe(serviceName) + "_" + el.name(), Struct);
+        }
+            
         else if (el instanceof EnumElement)
+        {
             return plain("E" + mixedCharacterStringToCppSafe(serviceName) + "_" + el.name(), Enum);
+        }
         else
+        {
             throw new RuntimeException("Unknown type: '" + el.getClass().getName() + "'");
+        }
+        // s6fix_end
     }
 
 

--- a/src/main/java/com/vizor/unreal/convert/ProtoProcessor.java
+++ b/src/main/java/com/vizor/unreal/convert/ProtoProcessor.java
@@ -13,6 +13,11 @@
  * License for the specific language governing permissions and limitations
  * under the License.
  */
+
+/*
+ * Modified 2021 by Singularity 6, Inc.
+ */
+
 package com.vizor.unreal.convert;
 
 import com.squareup.wire.schema.internal.parser.EnumConstantElement;

--- a/src/main/java/com/vizor/unreal/convert/ProtoProcessor.java
+++ b/src/main/java/com/vizor/unreal/convert/ProtoProcessor.java
@@ -467,12 +467,12 @@ class ProtoProcessor implements Runnable
     {
         if (el instanceof MessageElement)
         {
-            return plain("F" + serviceName + "_" + mixedCaseSnakeCaseToPascalCase(el.name()), Struct);
+            return plain("F" + serviceName + "_" + el.name(), Struct);
         }
             
         else if (el instanceof EnumElement)
         {
-            return plain("E" + serviceName + "_" + mixedCaseSnakeCaseToPascalCase(el.name()), Enum);
+            return plain("E" + serviceName + "_" + el.name(), Enum);
         }
         else
         {

--- a/src/main/java/com/vizor/unreal/convert/ProtoProcessor.java
+++ b/src/main/java/com/vizor/unreal/convert/ProtoProcessor.java
@@ -61,9 +61,9 @@ import static com.vizor.unreal.tree.CppRecord.Residence.Header;
 import static com.vizor.unreal.tree.CppType.Kind.Enum;
 import static com.vizor.unreal.tree.CppType.Kind.Struct;
 import static com.vizor.unreal.tree.CppType.plain;
-import static com.vizor.unreal.util.Misc.mixedCharacterStringToCppSafe;
+import static com.vizor.unreal.util.Misc.unsafeNameToSnakeCase;
 import static com.vizor.unreal.util.Misc.reorder;
-import static com.vizor.unreal.util.Misc.snakeCaseToCamelCase;
+import static com.vizor.unreal.util.Misc.mixedCaseSnakeCaseToPascalCase;
 import static com.vizor.unreal.util.Misc.stringIsNullOrEmpty;
 import static com.vizor.unreal.util.Tuple.of;
 import static java.lang.String.join;
@@ -85,7 +85,7 @@ class ProtoProcessorArgs
         this.pathToConverted = requireNonNull(pathToConverted2);
         this.moduleName = requireNonNull(moduleName);
 
-        this.wrapperName = mixedCharacterStringToCppSafe(removeExtension(pathToProto.toFile().getName()));
+        this.wrapperName = mixedCaseSnakeCaseToPascalCase(unsafeNameToSnakeCase(removeExtension(pathToProto.toFile().getName())));
 
         this.className = wrapperName;
 
@@ -467,12 +467,12 @@ class ProtoProcessor implements Runnable
     {
         if (el instanceof MessageElement)
         {
-            return plain("F" + serviceName + "_" + mixedCharacterStringToCppSafe(el.name()), Struct);
+            return plain("F" + serviceName + "_" + mixedCaseSnakeCaseToPascalCase(el.name()), Struct);
         }
             
         else if (el instanceof EnumElement)
         {
-            return plain("E" + serviceName + "_" + mixedCharacterStringToCppSafe(el.name()), Enum);
+            return plain("E" + serviceName + "_" + mixedCaseSnakeCaseToPascalCase(el.name()), Enum);
         }
         else
         {

--- a/src/main/java/com/vizor/unreal/convert/ProtoProcessor.java
+++ b/src/main/java/com/vizor/unreal/convert/ProtoProcessor.java
@@ -68,7 +68,7 @@ import static com.vizor.unreal.tree.CppType.Kind.Struct;
 import static com.vizor.unreal.tree.CppType.plain;
 import static com.vizor.unreal.util.Misc.unsafeNameToSnakeCase;
 import static com.vizor.unreal.util.Misc.reorder;
-import static com.vizor.unreal.util.Misc.mixedCaseSnakeCaseToPascalCase;
+import static com.vizor.unreal.util.Misc.mixedCaseToPascalCase;
 import static com.vizor.unreal.util.Misc.stringIsNullOrEmpty;
 import static com.vizor.unreal.util.Tuple.of;
 import static java.lang.String.join;
@@ -90,7 +90,7 @@ class ProtoProcessorArgs
         this.pathToConverted = requireNonNull(pathToConverted2);
         this.moduleName = requireNonNull(moduleName);
 
-        this.wrapperName = mixedCaseSnakeCaseToPascalCase(unsafeNameToSnakeCase(removeExtension(pathToProto.toFile().getName())));
+        this.wrapperName = mixedCaseToPascalCase(unsafeNameToSnakeCase(removeExtension(pathToProto.toFile().getName())));
 
         this.className = wrapperName;
 

--- a/src/main/java/com/vizor/unreal/convert/ProtoProcessor.java
+++ b/src/main/java/com/vizor/unreal/convert/ProtoProcessor.java
@@ -87,7 +87,7 @@ class ProtoProcessorArgs
         this.pathToConverted = requireNonNull(pathToConverted2);
         this.moduleName = requireNonNull(moduleName);
 
-        // s6fix @bernst - Generate C++ safe and compilable code. I haven't confirmed this helps anything. We probably should wrap pathToProto above to be safe as well, since that probably affects the generated file, and macro that can fail to compile.
+        // s6fix @bernst - Generate C++ safe and compilable code.
         this.wrapperName = mixedCharacterStringToCppSafe(removeExtension(pathToProto.toFile().getName()));
 
         this.className = wrapperName;
@@ -274,8 +274,10 @@ class ProtoProcessor implements Runnable
         final Config config = Config.get();
 
         // TODO: Fix paths
+        // s6fix @bernst - Generate C++ safe and compilable code.
         final String generatedIncludeName = join("/", config.getWrappersPath(),
-                removeExtension(pathToProtoStr)).replace("\\", pathSeparator);//, args.wrapperName);
+                pathToProtoStr).replace("\\", pathSeparator);//, args.wrapperName);
+        // s6fix_end
 
         final String generatedHeaderPath = getHeaderPath(args);
                 
@@ -472,12 +474,12 @@ class ProtoProcessor implements Runnable
         // s6fix @bernst - Generate C++ safe and compilable code.
         if (el instanceof MessageElement)
         {
-            return plain("F" + mixedCharacterStringToCppSafe(serviceName) + "_" + el.name(), Struct);
+            return plain("F" + serviceName + "_" + mixedCharacterStringToCppSafe(el.name()), Struct);
         }
             
         else if (el instanceof EnumElement)
         {
-            return plain("E" + mixedCharacterStringToCppSafe(serviceName) + "_" + el.name(), Enum);
+            return plain("E" + serviceName + "_" + mixedCharacterStringToCppSafe(el.name()), Enum);
         }
         else
         {

--- a/src/main/java/com/vizor/unreal/convert/ProtoProcessor.java
+++ b/src/main/java/com/vizor/unreal/convert/ProtoProcessor.java
@@ -61,9 +61,7 @@ import static com.vizor.unreal.tree.CppRecord.Residence.Header;
 import static com.vizor.unreal.tree.CppType.Kind.Enum;
 import static com.vizor.unreal.tree.CppType.Kind.Struct;
 import static com.vizor.unreal.tree.CppType.plain;
-// s6fix @bernst - Generate C++ safe and compilable code.
 import static com.vizor.unreal.util.Misc.mixedCharacterStringToCppSafe;
-// s6fix_end
 import static com.vizor.unreal.util.Misc.reorder;
 import static com.vizor.unreal.util.Misc.snakeCaseToCamelCase;
 import static com.vizor.unreal.util.Misc.stringIsNullOrEmpty;
@@ -87,11 +85,9 @@ class ProtoProcessorArgs
         this.pathToConverted = requireNonNull(pathToConverted2);
         this.moduleName = requireNonNull(moduleName);
 
-        // s6fix @bernst - Generate C++ safe and compilable code.
         this.wrapperName = mixedCharacterStringToCppSafe(removeExtension(pathToProto.toFile().getName()));
 
         this.className = wrapperName;
-        // s6fix_end
 
 //        if (parse.packageName() == null)
 //            throw new RuntimeException("package filed in proto file is required for cornerstone");
@@ -274,10 +270,8 @@ class ProtoProcessor implements Runnable
         final Config config = Config.get();
 
         // TODO: Fix paths
-        // s6fix @bernst - removeExtension was already called on pathToProtoStr above, calling it again can remove strings with periods intended to be in the name.
         final String generatedIncludeName = join("/", config.getWrappersPath(),
                 pathToProtoStr).replace("\\", pathSeparator);//, args.wrapperName);
-        // s6fix_end
 
         final String generatedHeaderPath = getHeaderPath(args);
                 
@@ -471,7 +465,6 @@ class ProtoProcessor implements Runnable
 
     private CppType ueNamedType(final String serviceName, final TypeElement el)
     {
-        // s6fix @bernst - Generate C++ safe and compilable code.
         if (el instanceof MessageElement)
         {
             return plain("F" + serviceName + "_" + mixedCharacterStringToCppSafe(el.name()), Struct);
@@ -485,7 +478,6 @@ class ProtoProcessor implements Runnable
         {
             throw new RuntimeException("Unknown type: '" + el.getClass().getName() + "'");
         }
-        // s6fix_end
     }
 
 

--- a/src/main/java/com/vizor/unreal/convert/ProtoProcessor.java
+++ b/src/main/java/com/vizor/unreal/convert/ProtoProcessor.java
@@ -274,7 +274,7 @@ class ProtoProcessor implements Runnable
         final Config config = Config.get();
 
         // TODO: Fix paths
-        // s6fix @bernst - Generate C++ safe and compilable code.
+        // s6fix @bernst - removeExtension was already called on pathToProtoStr above, calling it again can remove strings with periods intended to be in the name.
         final String generatedIncludeName = join("/", config.getWrappersPath(),
                 pathToProtoStr).replace("\\", pathSeparator);//, args.wrapperName);
         // s6fix_end

--- a/src/main/java/com/vizor/unreal/tree/CppNamespace.java
+++ b/src/main/java/com/vizor/unreal/tree/CppNamespace.java
@@ -31,7 +31,7 @@ public final class CppNamespace extends CppRecord
 
     public CppNamespace(final String name)
     {
-        this.name = name;
+        this.name = name.replace(".", "::");
     }
 
     public void add(final CppRecord... residents)

--- a/src/main/java/com/vizor/unreal/tree/CppNamespace.java
+++ b/src/main/java/com/vizor/unreal/tree/CppNamespace.java
@@ -16,9 +16,7 @@
 package com.vizor.unreal.tree;
 
 import com.vizor.unreal.writer.CppPrinter;
-// s6fix @bernst - Generate C++ safe and compilable code.
 import static com.vizor.unreal.util.Misc.packageNameToCppNamespace;
-// s6fix_end
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -34,9 +32,7 @@ public final class CppNamespace extends CppRecord
 
     public CppNamespace(final String name)
     {
-        // s6fix @bernst - Generate C++ safe and compilable code.
         this.name = packageNameToCppNamespace(name);
-        // s6fix_end
     }
 
     public void add(final CppRecord... residents)

--- a/src/main/java/com/vizor/unreal/tree/CppNamespace.java
+++ b/src/main/java/com/vizor/unreal/tree/CppNamespace.java
@@ -16,6 +16,9 @@
 package com.vizor.unreal.tree;
 
 import com.vizor.unreal.writer.CppPrinter;
+// s6fix @bernst - Generate C++ safe and compilable code.
+import static com.vizor.unreal.util.Misc.packageNameToCppNamespace;
+// s6fix_end
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -31,7 +34,9 @@ public final class CppNamespace extends CppRecord
 
     public CppNamespace(final String name)
     {
-        this.name = name.replace(".", "::");
+        // s6fix @bernst - Generate C++ safe and compilable code.
+        this.name = packageNameToCppNamespace(name);
+        // s6fix_end
     }
 
     public void add(final CppRecord... residents)

--- a/src/main/java/com/vizor/unreal/tree/CppNamespace.java
+++ b/src/main/java/com/vizor/unreal/tree/CppNamespace.java
@@ -13,6 +13,11 @@
  * License for the specific language governing permissions and limitations
  * under the License.
  */
+
+/*
+ * Modified 2021 by Singularity 6, Inc.
+ */
+
 package com.vizor.unreal.tree;
 
 import com.vizor.unreal.writer.CppPrinter;

--- a/src/main/java/com/vizor/unreal/util/Misc.java
+++ b/src/main/java/com/vizor/unreal/util/Misc.java
@@ -251,12 +251,23 @@ public class Misc
     /**
      * Converts a string like com.s6.core to com_s6_core.
      * 
-     * @return Input com.s6.core string transformed to ComS6Core.
+     * @return Input "com.s6.core" string transformed to "ComS6Core"
      */
     public static String mixedCharacterStringToCppSafe(final String mixedCharacterString)
     {
-        return snakeCaseToCamelCase(mixedCharacterString.replaceAll("[\\.\\-]", "_"));
+        return snakeCaseToCamelCase(mixedCharacterString.replaceAll("[.-]", "_"));
     }
+
+    /**
+     * Takes a Java package name and turns it into a C++ safe namespace.
+     *
+     * @return Input "com.s6.palia.imageservice" string transformed to "com::s6::palia::imageservice"
+     */
+    public static String packageNameToCppNamespace(final String packageName)
+    {
+        return packageName.replace(".", "::");
+    }
+
     // s6fix_end
 
     /**

--- a/src/main/java/com/vizor/unreal/util/Misc.java
+++ b/src/main/java/com/vizor/unreal/util/Misc.java
@@ -249,13 +249,54 @@ public class Misc
     // s6fix @bernst - Generate C++ safe and compilable code.
 
     /**
-     * Converts a string like com.s6.core to com_s6_core.
+     * Converts a string like "com.s6.core.image-service" to ComS6CoreImageService.
+     * Preserves case, except to upper case first letter to a word, where words are separated by underscores.
+     *
+     * In the future we can consider reworking the code to transform ssomething like "com.s6.core.image-service to "ComS6Core_ImageService".
      * 
-     * @return Input "com.s6.core" string transformed to "ComS6Core"
+     * @return Input "com.s6.core.image-service" to "ComS6CoreImageService"
      */
     public static String mixedCharacterStringToCppSafe(final String mixedCharacterString)
     {
-        return snakeCaseToCamelCase(mixedCharacterString.replaceAll("[.-]", "_"));
+        // Transforms input "com.s6.core.image-service" to "com_s6_core_image_service"
+        final String cppSafeString = mixedCharacterString.replaceAll("[.-]", "_");
+        
+        // Below here, transforms input "com_s6_core_image_service" to "ComS6CoreImageService"
+
+        // snakeCaseToCamelCase but modified to leave existing case alone.
+        // Some strings that come in here are mostly preformated, leave the case alone.
+        final StringBuilder sb = new StringBuilder(cppSafeString.length());
+
+        // Split our snake case string by snake separator, simultaneously excluding empty strings
+        // This is faster than more sophisticated regex.
+        final String[] split = stream(cppSafeString.split("_"))
+                .filter(i -> i.length() != 0)
+                .toArray(String[]::new);
+
+        if (split.length == 0)
+        {
+            return cppSafeString;
+        }
+
+        for (int i = 0; i < split.length; i++)
+        {
+            String s = split[i];
+            final int wordLength = s.length();
+
+            if (wordLength > 0)
+            {
+                // The first letter may be either lower or upper case, depending of 'firstLetterIsCapital' flag
+                final char firstLetter = toUpperCase(s.charAt(0));
+                sb.append(firstLetter);
+
+                if (wordLength > 1)
+                {
+                    sb.append(s.substring(1));
+                }
+            }
+        }
+
+        return sb.toString();
     }
 
     /**

--- a/src/main/java/com/vizor/unreal/util/Misc.java
+++ b/src/main/java/com/vizor/unreal/util/Misc.java
@@ -246,8 +246,6 @@ public class Misc
         }
     }
 
-    // s6fix @bernst - Generate C++ safe and compilable code.
-
     /**
      * Converts a string like "com.s6.core.image-service" to ComS6CoreImageService.
      * Preserves case, except to upper case first letter to a word, where words are separated by underscores.
@@ -308,8 +306,6 @@ public class Misc
     {
         return packageName.replace(".", "::");
     }
-
-    // s6fix_end
 
     /**
      * Transforms snake_case_string into camelCaseString.

--- a/src/main/java/com/vizor/unreal/util/Misc.java
+++ b/src/main/java/com/vizor/unreal/util/Misc.java
@@ -247,19 +247,19 @@ public class Misc
     }
 
     /**
-     * Converts a string like "com.s6.core.image-service" to ComS6CoreImageService.
+     * Converts a string like "com.org.core.service-name" to ComOrgCoreServiceName.
      * Preserves case, except to upper case first letter to a word, where words are separated by underscores.
      *
-     * In the future we can consider reworking the code to transform ssomething like "com.s6.core.image-service to "ComS6Core_ImageService".
+     * In the future we can consider reworking the code to transform ssomething like "com.org.core.service-name to "ComorgCore_ServiceName".
      * 
-     * @return Input "com.s6.core.image-service" to "ComS6CoreImageService"
+     * @return Input "com.org.core.service-name" to "ComOrgCoreServiceName"
      */
     public static String mixedCharacterStringToCppSafe(final String mixedCharacterString)
     {
-        // Transforms input "com.s6.core.image-service" to "com_s6_core_image_service"
+        // Transforms input "com.org.core.service-name" to "com_org_core_Service_Name"
         final String cppSafeString = mixedCharacterString.replaceAll("[.-]", "_");
         
-        // Below here, transforms input "com_s6_core_image_service" to "ComS6CoreImageService"
+        // Below here, transforms input "com_org_core_Service_Name" to "ComOrgCoreServiceName"
 
         // snakeCaseToCamelCase but modified to leave existing case alone.
         // Some strings that come in here are mostly preformated, leave the case alone.
@@ -300,7 +300,7 @@ public class Misc
     /**
      * Takes a Java package name and turns it into a C++ safe namespace.
      *
-     * @return Input "com.s6.palia.imageservice" string transformed to "com::s6::palia::imageservice"
+     * @return Input "com.org.project.servicename" string transformed to "com::org::project::servicename"
      */
     public static String packageNameToCppNamespace(final String packageName)
     {

--- a/src/main/java/com/vizor/unreal/util/Misc.java
+++ b/src/main/java/com/vizor/unreal/util/Misc.java
@@ -246,6 +246,8 @@ public class Misc
         }
     }
 
+    // s6fix @bernst - Generate C++ safe and compilable code.
+
     /**
      * Converts a string like com.s6.core to com_s6_core.
      * 
@@ -255,6 +257,7 @@ public class Misc
     {
         return snakeCaseToCamelCase(mixedCharacterString.replaceAll("[\\.\\-]", "_"));
     }
+    // s6fix_end
 
     /**
      * Transforms snake_case_string into camelCaseString.

--- a/src/main/java/com/vizor/unreal/util/Misc.java
+++ b/src/main/java/com/vizor/unreal/util/Misc.java
@@ -268,17 +268,6 @@ public class Misc
     }
 
     /**
-     * Transforms snake_case_string into camelCaseString.
-     * @param snakeCaseString String in snake_case.
-     *
-     * @return Input snake_case string transformed to camelCase.
-     */
-    public static String snakeCaseToCamelCase(final String snakeCaseString)
-    {
-        return snakeCaseToCamelCase(snakeCaseString, true);
-    }
-
-    /**
      * Transforms snake_case to PascalString.
      * @param pascalCaseString String in mixed case snake_case
      *
@@ -311,6 +300,17 @@ public class Misc
         }
 
         return sb.toString();
+    }
+
+    /**
+     * Transforms snake_case_string into camelCaseString.
+     * @param snakeCaseString String in snake_case.
+     *
+     * @return Input snake_case string transformed to camelCase.
+     */
+    public static String snakeCaseToCamelCase(final String snakeCaseString)
+    {
+        return snakeCaseToCamelCase(snakeCaseString, true);
     }
 
     /**

--- a/src/main/java/com/vizor/unreal/util/Misc.java
+++ b/src/main/java/com/vizor/unreal/util/Misc.java
@@ -250,16 +250,16 @@ public class Misc
      * Converts a string like "com.org.core.service-name" to ComOrgCoreServiceName.
      * Preserves case, except to upper case first letter to a word, where words are separated by underscores.
      *
-     * In the future we can consider reworking the code to transform ssomething like "com.org.core.service-name to "ComorgCore_ServiceName".
+     * In the future we can consider reworking the code to transform ssomething like "com.org.core.service-name to "ComOrgCore_ServiceName".
      * 
      * @return Input "com.org.core.service-name" to "ComOrgCoreServiceName"
      */
     public static String mixedCharacterStringToCppSafe(final String mixedCharacterString)
     {
-        // Transforms input "com.org.core.service-name" to "com_org_core_Service_Name"
+        // Transforms input "com.org.core.service-name" to "com_org_core_service_name"
         final String cppSafeString = mixedCharacterString.replaceAll("[.-]", "_");
         
-        // Below here, transforms input "com_org_core_Service_Name" to "ComOrgCoreServiceName"
+        // Below here, transforms input "com_org_core_service_name" to "ComOrgCoreServiceName"
 
         // snakeCaseToCamelCase but modified to leave existing case alone.
         // Some strings that come in here are mostly preformated, leave the case alone.

--- a/src/main/java/com/vizor/unreal/util/Misc.java
+++ b/src/main/java/com/vizor/unreal/util/Misc.java
@@ -273,18 +273,19 @@ public class Misc
     }
 
     /**
-     * Transforms snake_case to PascalString.
-     * @param pascalCaseString String in mixed case snake_case
+     * Transforms mixedCase_String to PascalString.
+     * Only transforms starting letter to upper case and maintains mixed case in the rest of the word. If you pass this function a PascalString, it should return that same PascalString.
+     * @param mixedCaseString String in mixedCase or snake_string.
      *
-     * @return Input 'org_core_pascal_case' string transformed to 'OrgCorePascalCase'.
+     * @return Input 'orgCore_pascalCase' string transformed to 'OrgCorePascalCase'.
      */
-    public static String mixedCaseSnakeCaseToPascalCase(final String pascalCaseString)
+    public static String mixedCaseToPascalCase(final String mixedCaseString)
     {
-        final StringBuilder sb = new StringBuilder(pascalCaseString.length());
+        final StringBuilder sb = new StringBuilder(mixedCaseString.length());
 
         // Split our snake case string by snake separator, simultaneously excluding empty strings
         // This is faster than more sophisticated regex.
-        final String[] split = stream(pascalCaseString.split("_"))
+        final String[] split = stream(mixedCaseString.split("_"))
                 .filter(i -> i.length() != 0)
                 .toArray(String[]::new);
 

--- a/src/main/java/com/vizor/unreal/util/Misc.java
+++ b/src/main/java/com/vizor/unreal/util/Misc.java
@@ -247,54 +247,13 @@ public class Misc
     }
 
     /**
-     * Converts a string like "com.org.core.service-name" to ComOrgCoreServiceName.
-     * Preserves case, except to upper case first letter to a word, where words are separated by underscores.
-     *
-     * In the future we can consider reworking the code to transform ssomething like "com.org.core.service-name to "ComOrgCore_ServiceName".
+     * Converts an "unsafe" name string like "com.org.core.service-name" to "ComOrgCoreServiceName". Unsafe in this case means a string that can't be compiled to a generated code field name, or what have you.
      * 
-     * @return Input "com.org.core.service-name" to "ComOrgCoreServiceName"
+     * @return Input "com.org.core.service-name" to "com_org_core_service_name"
      */
-    public static String mixedCharacterStringToCppSafe(final String mixedCharacterString)
+    public static String unsafeNameToSnakeCase(final String unsafeName)
     {
-        // Transforms input "com.org.core.service-name" to "com_org_core_service_name"
-        final String cppSafeString = mixedCharacterString.replaceAll("[.-]", "_");
-        
-        // Below here, transforms input "com_org_core_service_name" to "ComOrgCoreServiceName"
-
-        // snakeCaseToCamelCase but modified to leave existing case alone.
-        // Some strings that come in here are mostly preformated, leave the case alone.
-        final StringBuilder sb = new StringBuilder(cppSafeString.length());
-
-        // Split our snake case string by snake separator, simultaneously excluding empty strings
-        // This is faster than more sophisticated regex.
-        final String[] split = stream(cppSafeString.split("_"))
-                .filter(i -> i.length() != 0)
-                .toArray(String[]::new);
-
-        if (split.length == 0)
-        {
-            return cppSafeString;
-        }
-
-        for (int i = 0; i < split.length; i++)
-        {
-            String s = split[i];
-            final int wordLength = s.length();
-
-            if (wordLength > 0)
-            {
-                // The first letter may be either lower or upper case, depending of 'firstLetterIsCapital' flag
-                final char firstLetter = toUpperCase(s.charAt(0));
-                sb.append(firstLetter);
-
-                if (wordLength > 1)
-                {
-                    sb.append(s.substring(1));
-                }
-            }
-        }
-
-        return sb.toString();
+        return unsafeName.replaceAll("[.-]", "_");
     }
 
     /**
@@ -316,6 +275,41 @@ public class Misc
     public static String snakeCaseToCamelCase(final String snakeCaseString)
     {
         return snakeCaseToCamelCase(snakeCaseString, true);
+    }
+
+    /**
+     * Transforms snake_case to PascalString.
+     * @param pascalCaseString String in mixed case snake_case
+     *
+     * @return Input 'org_core_pascal_case' string transformed to 'OrgCorePascalCase'.
+     */
+    public static String mixedCaseSnakeCaseToPascalCase(final String pascalCaseString)
+    {
+        final StringBuilder sb = new StringBuilder(pascalCaseString.length());
+
+        // Split our snake case string by snake separator, simultaneously excluding empty strings
+        // This is faster than more sophisticated regex.
+        final String[] split = stream(pascalCaseString.split("_"))
+                .filter(i -> i.length() != 0)
+                .toArray(String[]::new);
+
+        for (int i = 0; i < split.length; i++)
+        {
+            String s = split[i];
+            final int wordLength = s.length();
+
+            if (wordLength > 0)
+            {
+                final char firstLetter = toUpperCase(s.charAt(0));
+
+                sb.append(firstLetter);
+
+                if (wordLength > 1)
+                    sb.append(s.substring(1));
+            }
+        }
+
+        return sb.toString();
     }
 
     /**

--- a/src/main/java/com/vizor/unreal/util/Misc.java
+++ b/src/main/java/com/vizor/unreal/util/Misc.java
@@ -13,6 +13,11 @@
  * License for the specific language governing permissions and limitations
  * under the License.
  */
+
+/*
+ * Modified 2021 by Singularity 6, Inc.
+ */
+
 package com.vizor.unreal.util;
 
 import org.apache.logging.log4j.Level;
@@ -247,8 +252,8 @@ public class Misc
     }
 
     /**
-     * Converts an "unsafe" name string like "com.org.core.service-name" to "ComOrgCoreServiceName". Unsafe in this case means a string that can't be compiled to a generated code field name, or what have you. 
-     * 
+     * Converts an "unsafe" field name to a string that can be compiled in a C-like language. 
+     * Not yet all inclusive, doesn't strip all unsafe characters, just commonly usesd ones in file names where the file name is used in a generated name.
      * 
      * @return Input "com.org.core.service-name" to "com_org_core_service_name". Preserves case, not strict snake case; ComOrg.ServiceName to ComOrg_ServiceName.
      */

--- a/src/main/java/com/vizor/unreal/util/Misc.java
+++ b/src/main/java/com/vizor/unreal/util/Misc.java
@@ -247,9 +247,10 @@ public class Misc
     }
 
     /**
-     * Converts an "unsafe" name string like "com.org.core.service-name" to "ComOrgCoreServiceName". Unsafe in this case means a string that can't be compiled to a generated code field name, or what have you.
+     * Converts an "unsafe" name string like "com.org.core.service-name" to "ComOrgCoreServiceName". Unsafe in this case means a string that can't be compiled to a generated code field name, or what have you. 
      * 
-     * @return Input "com.org.core.service-name" to "com_org_core_service_name"
+     * 
+     * @return Input "com.org.core.service-name" to "com_org_core_service_name". Preserves case, not strict snake case; ComOrg.ServiceName to ComOrg_ServiceName.
      */
     public static String unsafeNameToSnakeCase(final String unsafeName)
     {

--- a/src/main/java/com/vizor/unreal/util/Misc.java
+++ b/src/main/java/com/vizor/unreal/util/Misc.java
@@ -247,6 +247,16 @@ public class Misc
     }
 
     /**
+     * Converts a string like com.s6.core to com_s6_core.
+     * 
+     * @return Input com.s6.core string transformed to ComS6Core.
+     */
+    public static String mixedCharacterStringToCppSafe(final String mixedCharacterString)
+    {
+        return snakeCaseToCamelCase(mixedCharacterString.replaceAll("[\\.\\-]", "_"));
+    }
+
+    /**
      * Transforms snake_case_string into camelCaseString.
      * @param snakeCaseString String in snake_case.
      *

--- a/src/test/java/com/vizor/unreal/MiscTest.java
+++ b/src/test/java/com/vizor/unreal/MiscTest.java
@@ -29,7 +29,7 @@ import java.util.Random;
 
 import static com.vizor.unreal.util.Misc.TAB;
 
-import static com.vizor.unreal.util.Misc.mixedCaseSnakeCaseToPascalCase;
+import static com.vizor.unreal.util.Misc.mixedCaseToPascalCase;
 import static com.vizor.unreal.util.Misc.packageNameToCppNamespace;
 import static com.vizor.unreal.util.Misc.removeWhitespaces;
 import static com.vizor.unreal.util.Misc.reorder;
@@ -136,15 +136,15 @@ public class MiscTest
     }
 
     @Test
-    public void testMixedCaseSnakeCaseToPascalCase()
+    public void testmixedCaseToPascalCase()
     {
-        assertEquals(mixedCaseSnakeCaseToPascalCase("com_org_project"), "ComOrgProject");
-        assertEquals(mixedCaseSnakeCaseToPascalCase("Com_Org_Project"), "ComOrgProject");
-        assertEquals(mixedCaseSnakeCaseToPascalCase("ComOrgProject_ServiceName"), "ComOrgProjectServiceName");
+        assertEquals(mixedCaseToPascalCase("com_org_project"), "ComOrgProject");
+        assertEquals(mixedCaseToPascalCase("Com_Org_Project"), "ComOrgProject");
+        assertEquals(mixedCaseToPascalCase("ComOrgProject_ServiceName"), "ComOrgProjectServiceName");
 
-        assertEquals(mixedCaseSnakeCaseToPascalCase("__com__org__project"), "ComOrgProject");
-        assertEquals(mixedCaseSnakeCaseToPascalCase("com__org__project__"), "ComOrgProject");
-        assertEquals(mixedCaseSnakeCaseToPascalCase("_com__org__project_"), "ComOrgProject");
+        assertEquals(mixedCaseToPascalCase("__com__org__project"), "ComOrgProject");
+        assertEquals(mixedCaseToPascalCase("com__org__project__"), "ComOrgProject");
+        assertEquals(mixedCaseToPascalCase("_com__org__project_"), "ComOrgProject");
     }
 
     @Test

--- a/src/test/java/com/vizor/unreal/MiscTest.java
+++ b/src/test/java/com/vizor/unreal/MiscTest.java
@@ -23,12 +23,16 @@ import java.util.List;
 import java.util.Random;
 
 import static com.vizor.unreal.util.Misc.TAB;
+
+import static com.vizor.unreal.util.Misc.mixedCaseSnakeCaseToPascalCase;
+import static com.vizor.unreal.util.Misc.packageNameToCppNamespace;
 import static com.vizor.unreal.util.Misc.removeWhitespaces;
 import static com.vizor.unreal.util.Misc.reorder;
 import static com.vizor.unreal.util.Misc.snakeCaseToCamelCase;
 import static com.vizor.unreal.util.Misc.spaceSeparatedToCamelCase;
 import static com.vizor.unreal.util.Misc.splitGeneric;
 import static com.vizor.unreal.util.Misc.stringIsNullOrEmpty;
+import static com.vizor.unreal.util.Misc.unsafeNameToSnakeCase;
 import static java.lang.String.join;
 import static java.util.Arrays.asList;
 import static java.util.Collections.shuffle;
@@ -100,6 +104,42 @@ public class MiscTest
         reorder(integers, new int[]{0, 1, 2, 2, 1, 0});
 
         assertEquals(integers, asList(10, 20, 30, 30, 20, 10));
+    }
+
+    @Test
+    public void testPackageNameToCppNamespace()
+    {
+        assertEquals(packageNameToCppNamespace("com.org.project"), "com::org::project");
+        assertEquals(packageNameToCppNamespace("Com.Org.Project"), "Com::Org::Project");
+
+        assertEquals(packageNameToCppNamespace("com.org.project.service_name"), "com::org::project::service_name");
+        assertEquals(packageNameToCppNamespace("Com.Org.Project.Service_Name"), "Com::Org::Project::Service_Name");
+
+        assertEquals(packageNameToCppNamespace("Com.Org.Project.Service__Name"), "Com::Org::Project::Service__Name");
+    }
+
+    @Test
+    public void testUnsafeNameToSnakeCase()
+    {
+        assertEquals(unsafeNameToSnakeCase("com.org.project"), "com_org_project");
+        assertEquals(unsafeNameToSnakeCase("Com.Org.Project"), "Com_Org_Project");
+
+        assertEquals(unsafeNameToSnakeCase("ComOrgProject.ServiceName"), "ComOrgProject_ServiceName");
+        assertEquals(unsafeNameToSnakeCase("ComOrgProject.Service-Name"), "ComOrgProject_Service_Name");
+
+        assertEquals(unsafeNameToSnakeCase("ComOrgProject.Service-Name_ActionName"), "ComOrgProject_Service_Name_ActionName");
+    }
+
+    @Test
+    public void testMixedCaseSnakeCaseToPascalCase()
+    {
+        assertEquals(mixedCaseSnakeCaseToPascalCase("com_org_project"), "ComOrgProject");
+        assertEquals(mixedCaseSnakeCaseToPascalCase("Com_Org_Project"), "ComOrgProject");
+        assertEquals(mixedCaseSnakeCaseToPascalCase("ComOrgProject_ServiceName"), "ComOrgProjectServiceName");
+
+        assertEquals(mixedCaseSnakeCaseToPascalCase("__com__org__project"), "ComOrgProject");
+        assertEquals(mixedCaseSnakeCaseToPascalCase("com__org__project__"), "ComOrgProject");
+        assertEquals(mixedCaseSnakeCaseToPascalCase("_com__org__project_"), "ComOrgProject");
     }
 
     @Test

--- a/src/test/java/com/vizor/unreal/MiscTest.java
+++ b/src/test/java/com/vizor/unreal/MiscTest.java
@@ -13,6 +13,11 @@
  * License for the specific language governing permissions and limitations
  * under the License.
  */
+
+/*
+ * Modified 2021 by Singularity 6, Inc.
+ */
+
 package com.vizor.unreal;
 
 import com.vizor.unreal.util.Misc;


### PR DESCRIPTION
Support filenames with periods/hyphens in the name, because they contain the package name, and package names with periods. 

Example: file named `com.s6.core.image-service.v1.proto`, with package named `com.s6.core`, or even `com.s6.core.image-service`. Cornerstone generated types and namespaces with periods or hyphens in them, which don't compile. 