### PR TITLE
Make client API functions take success/failure delegates as parameter…

### DIFF
--- a/src/main/java/com/vizor/unreal/convert/CastGenerator.java
+++ b/src/main/java/com/vizor/unreal/convert/CastGenerator.java
@@ -13,6 +13,11 @@
  * License for the specific language governing permissions and limitations
  * under the License.
  */
+ 
+/*
+ * Modified 2021 by Singularity 6, Inc.
+ */
+ 
 package com.vizor.unreal.convert;
 
 import com.vizor.unreal.tree.CppArgument;

--- a/src/main/java/com/vizor/unreal/convert/ProtoProcessor.java
+++ b/src/main/java/com/vizor/unreal/convert/ProtoProcessor.java
@@ -231,7 +231,7 @@ class ProtoProcessor implements Runnable
             final ClientGenerator cg = new ClientGenerator(service, ueProvider, worker.getType());
 
             clients.add(cg.genClientClass());
-            dispatchers.addAll(cg.getDelegates());
+            dispatchers.addAll(cg.getGlobalDelegates());
         }
 
         final String pathToProtoStr = removeExtension(args.pathToProto.toString());

--- a/src/main/java/com/vizor/unreal/tree/CppClass.java
+++ b/src/main/java/com/vizor/unreal/tree/CppClass.java
@@ -25,13 +25,15 @@ import static java.util.Collections.unmodifiableList;
 public class CppClass extends CppStruct
 {
     private final CppType superType;
+    private final List<CppDelegate> delegateTypes;
     private final List<CppFunction> methods;
 
-    public CppClass(final CppType type, final CppType superType, final List<CppField> fields, final List<CppFunction> methods)
+    public CppClass(final CppType type, final CppType superType, final List<CppDelegate> delegateTypes, final List<CppField> fields, final List<CppFunction> methods)
     {
         super(type, fields);
 
         this.superType = superType;
+        this.delegateTypes = delegateTypes;
         this.methods = unmodifiableList(methods);
 
         // Set each method's declaring class to this.
@@ -41,6 +43,8 @@ public class CppClass extends CppStruct
         // Assuming methods and
         setResidence(Split);
     }
+
+    public final List<CppDelegate> getDelegateTypes() { return delegateTypes; }
 
     public final List<CppFunction> getMethods()
     {

--- a/src/main/java/com/vizor/unreal/tree/CppClass.java
+++ b/src/main/java/com/vizor/unreal/tree/CppClass.java
@@ -13,6 +13,11 @@
  * License for the specific language governing permissions and limitations
  * under the License.
  */
+ 
+/*
+ * Modified 2021 by Singularity 6, Inc.
+ */
+ 
 package com.vizor.unreal.tree;
 
 import com.vizor.unreal.writer.CppPrinter;

--- a/src/main/java/com/vizor/unreal/tree/CppDelegate.java
+++ b/src/main/java/com/vizor/unreal/tree/CppDelegate.java
@@ -13,6 +13,11 @@
  * License for the specific language governing permissions and limitations
  * under the License.
  */
+ 
+/*
+ * Modified 2021 by Singularity 6, Inc.
+ */
+ 
 package com.vizor.unreal.tree;
 
 import com.vizor.unreal.writer.CppPrinter;

--- a/src/main/java/com/vizor/unreal/tree/CppDelegate.java
+++ b/src/main/java/com/vizor/unreal/tree/CppDelegate.java
@@ -23,13 +23,43 @@ import static java.util.Collections.unmodifiableList;
 
 public final class CppDelegate implements CtLeaf
 {
+    private final boolean isDynamicDelegate;
+    private final boolean isMulticastDelegate;
     private final CppType type;
     private final List<CppArgument> arguments;
 
-    public CppDelegate(final CppType type, final List<CppArgument> arguments)
+    public CppDelegate(final boolean isDynamicDelegate, final boolean isMulticastDelegate, final CppType type, final List<CppArgument> arguments)
     {
+        this.isDynamicDelegate = isDynamicDelegate;
+        this.isMulticastDelegate = isMulticastDelegate;
         this.type = type;
         this.arguments = unmodifiableList(arguments);
+    }
+
+    public final String getDelegateMacroStringBase()
+    {
+        if (isDynamicDelegate)
+        {
+            if (isMulticastDelegate)
+            {
+                return "DECLARE_DYNAMIC_MULTICAST_DELEGATE";
+            }
+            else
+            {
+                return "DECLARE_DYNAMIC_DELEGATE";
+            }
+        }
+        else
+        {
+            if (isMulticastDelegate)
+            {
+                return "DECLARE_MULTICAST_DELEGATE";
+            }
+            else
+            {
+                return "DECLARE_DELEGATE";
+            }
+        }
     }
 
     public String getTense()
@@ -66,5 +96,13 @@ public final class CppDelegate implements CtLeaf
     {
         printer.visit(this);
         return printer;
+    }
+
+    public final boolean isDynamicDelegate() {
+        return isDynamicDelegate;
+    }
+
+    public final boolean isMulticastDelegate() {
+        return isMulticastDelegate;
     }
 }

--- a/src/main/java/com/vizor/unreal/writer/CppPrinter.java
+++ b/src/main/java/com/vizor/unreal/writer/CppPrinter.java
@@ -13,6 +13,11 @@
  * License for the specific language governing permissions and limitations
  * under the License.
  */
+ 
+/*
+ * Modified 2021 by Singularity 6, Inc.
+ */
+ 
 package com.vizor.unreal.writer;
 
 import com.vizor.unreal.config.DestinationConfig;

--- a/src/main/java/com/vizor/unreal/writer/CppPrinter.java
+++ b/src/main/java/com/vizor/unreal/writer/CppPrinter.java
@@ -324,9 +324,17 @@ public class CppPrinter implements AutoCloseable
             code().newLine().header();
         current = previous;
 
-        writeInlineComment("Methods");
-        clazz.getMethods().forEach(m -> m.accept(this));
+        if (!clazz.getDelegateTypes().isEmpty()) {
+            writeInlineComment("Delegate Types");
+            clazz.getDelegateTypes().forEach(nt -> {nt.accept(this); newLine();});
 
+            newLine();
+        }
+
+        if (!clazz.getMethods().isEmpty()) {
+            writeInlineComment("Methods");
+            clazz.getMethods().forEach(m -> m.accept(this));
+        }
         switchWriterByResidence(clazz);
 
         removeLine();
@@ -469,7 +477,7 @@ public class CppPrinter implements AutoCloseable
 
     public void visit(final CppDelegate delegate)
     {
-        write("DECLARE_DYNAMIC_MULTICAST_DELEGATE");
+        write(delegate.getDelegateMacroStringBase());
 
         final String tense = delegate.getTense();
         if (!tense.isEmpty())
@@ -490,8 +498,16 @@ public class CppPrinter implements AutoCloseable
 
             argType.accept(this);
 
-            write(", ");
-            write(a.getName());
+            if (delegate.isDynamicDelegate()) {
+                write(", ");
+                write(a.getName());
+            }
+            else
+            {
+                write(" /*");
+                write(a.getName());
+                write("*/");
+            }
         }
         write(");");
     }


### PR DESCRIPTION
…s. For ideal workflows involving lambdas, these delegates should not be dynamic, which requires that the functions not be reflected.